### PR TITLE
Add support for Python; refactor support for Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 Sbt-thrift is an sbt plugin that adds a mixin for doing thrift code auto-generation during your
 compile phase. Choose one of these three:
 
+- `CompileThriftFinagle` - create the java bindings with alternative async interfaces for finagle, in `target/gen-java/`
 - `CompileThriftJava` - create just the java bindings, in `target/gen-java/`
-- `CompileThriftFinagle` - create the java bindings with alternative async interfaces for finagle,
-  in `target/gen-java/`
-- `CompileThriftScala` - do `CompileThriftFinagle`, but also generate scala wrappers and implicit
-  conversions in `target/gen-scala/`
+- `CompileThriftPython` - create just the python bindings, in `target/gen-py/`
+- `CompileThriftPythonTwisted` - create just the python bindings with twisted supprot, in `target/gen-py/`
+- `CompileThriftRuby` - create just the ruby bindings, in `target/gen-ruby/`
+- `CompileThriftScala` - do `CompileThriftFinagle` and `CompileThriftRuby`, but also generate scala wrappers and implicit conversions in `target/gen-scala/`

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ compile phase. Choose one of these three:
 - `CompileThriftFinagle` - create the java bindings with alternative async interfaces for finagle, in `target/gen-java/`
 - `CompileThriftJava` - create just the java bindings, in `target/gen-java/`
 - `CompileThriftPython` - create just the python bindings, in `target/gen-py/`
-- `CompileThriftPythonTwisted` - create just the python bindings with twisted supprot, in `target/gen-py/`
+- `CompileThriftPythonTwisted` - create just the python bindings with twisted support, in `target/gen-py/`
 - `CompileThriftRuby` - create just the ruby bindings, in `target/gen-ruby/`
 - `CompileThriftScala` - do `CompileThriftFinagle` and `CompileThriftRuby`, but also generate scala wrappers and implicit conversions in `target/gen-scala/`

--- a/src/main/scala/com/twitter/sbt/CompileThrift.scala
+++ b/src/main/scala/com/twitter/sbt/CompileThrift.scala
@@ -17,8 +17,8 @@ trait CompileThrift extends DefaultProject with GeneratedSources {
     import Process._
     outputPath.asFile.mkdirs()
     val tasks = thriftSources.getPaths.map { path =>
-      execTask { "%s --gen %s -o %s %s".format(thriftBin,lang, outputPath.absolutePath, path) }
+      execTask { "%s --gen %s -o %s %s".format(thriftBin, lang, outputPath.absolutePath, path) }
     }
     if (tasks.isEmpty) None else tasks.reduceLeft { _ && _ }.run
-  }
+  } describedAs("Compile thrift into %s".format(lang))
 }

--- a/src/main/scala/com/twitter/sbt/CompileThrift.scala
+++ b/src/main/scala/com/twitter/sbt/CompileThrift.scala
@@ -1,0 +1,24 @@
+package com.twitter.sbt
+
+import _root_.sbt._
+
+import scala.collection.jcl
+
+trait CompileThrift extends DefaultProject with GeneratedSources {
+  def thriftBin = jcl.Map(System.getenv()).get("THRIFT_BIN").getOrElse("thrift")
+
+  def thriftSources = (mainSourcePath / "thrift" ##) ** "*.thrift"
+
+  /** override to disable auto-compiling of thrift */
+  def autoCompileThriftEnabled = true
+
+  // thrift generation.
+  def compileThriftAction(lang: String) = task {
+    import Process._
+    outputPath.asFile.mkdirs()
+    val tasks = thriftSources.getPaths.map { path =>
+      execTask { "%s --gen %s -o %s %s".format(thriftBin,lang, outputPath.absolutePath, path) }
+    }
+    if (tasks.isEmpty) None else tasks.reduceLeft { _ && _ }.run
+  }
+}

--- a/src/main/scala/com/twitter/sbt/CompileThriftJava.scala
+++ b/src/main/scala/com/twitter/sbt/CompileThriftJava.scala
@@ -6,8 +6,9 @@ trait CompileThriftJava extends CompileThrift {
   lazy val compileThriftJava = compileThriftAction("java")
 
   lazy val autoCompileThriftJava = task {
-    if (autoCompileThriftEnabled) compileThriftJava.run
-    else {
+    if (autoCompileThriftEnabled) {
+      compileThriftJava.run
+    } else {
       log.info("%s: not auto-compiling thrift-java; you may need to run compile-thrift-java manually".format(name))
       None
     }

--- a/src/main/scala/com/twitter/sbt/CompileThriftJava.scala
+++ b/src/main/scala/com/twitter/sbt/CompileThriftJava.scala
@@ -3,13 +3,12 @@ package com.twitter.sbt
 import _root_.sbt._
 
 trait CompileThriftJava extends CompileThrift {
-  lazy val compileThriftJava =
-    compileThriftAction("java") describedAs("Compile thrift into java")
+  lazy val compileThriftJava = compileThriftAction("java")
 
   lazy val autoCompileThriftJava = task {
     if (autoCompileThriftEnabled) compileThriftJava.run
     else {
-      log.info(name+": not auto-compiling thrift-java; you may need to run compile-thrift-java manually")
+      log.info("%s: not auto-compiling thrift-java; you may need to run compile-thrift-java manually".format(name))
       None
     }
   }

--- a/src/main/scala/com/twitter/sbt/CompileThriftJava.scala
+++ b/src/main/scala/com/twitter/sbt/CompileThriftJava.scala
@@ -1,28 +1,10 @@
 package com.twitter.sbt
 
-import scala.collection.jcl
 import _root_.sbt._
 
-trait CompileThriftJava extends DefaultProject with GeneratedSources {
-  def thriftBin = jcl.Map(System.getenv()).get("THRIFT_BIN").getOrElse("thrift")
-
-  // thrift generation.
-  def compileThriftAction(lang: String) = task {
-    import Process._
-    outputPath.asFile.mkdirs()
-    val tasks = thriftSources.getPaths.map { path =>
-      execTask { "%s --gen %s -o %s %s".format(thriftBin,lang, outputPath.absolutePath, path) }
-    }
-    if (tasks.isEmpty) None else tasks.reduceLeft { _ && _ }.run
-  }
-
-  def thriftSources = (mainSourcePath / "thrift" ##) ** "*.thrift"
-
-  lazy val compileThriftJava = compileThriftAction("java") describedAs("Compile thrift into java")
-  lazy val compileThriftRuby = compileThriftAction("rb") describedAs("Compile thrift into ruby")
-
-  /** override to disable auto-compiling of thrift */
-  def autoCompileThriftEnabled = true
+trait CompileThriftJava extends CompileThrift {
+  lazy val compileThriftJava =
+    compileThriftAction("java") describedAs("Compile thrift into java")
 
   lazy val autoCompileThriftJava = task {
     if (autoCompileThriftEnabled) compileThriftJava.run
@@ -32,13 +14,5 @@ trait CompileThriftJava extends DefaultProject with GeneratedSources {
     }
   }
 
-  lazy val autoCompileThriftRuby = task {
-    if (autoCompileThriftEnabled) compileThriftRuby.run
-    else {
-      log.info(name+": not auto-compiling thrift-ruby; you may need to run compile-thrift-ruby manually")
-      None
-    }
-  }
-
-  override def compileAction = super.compileAction dependsOn(autoCompileThriftJava, autoCompileThriftRuby)
+  override def compileAction = super.compileAction dependsOn(autoCompileThriftJava)
 }

--- a/src/main/scala/com/twitter/sbt/CompileThriftPython.scala
+++ b/src/main/scala/com/twitter/sbt/CompileThriftPython.scala
@@ -8,9 +8,9 @@ trait CompileThriftPython extends CompileThrift {
   lazy val compileThriftPython = compileThriftAction(pythonThriftSpec)
 
   lazy val autoCompileThriftPython = task {
-    if (autoCompileThriftEnabled)
+    if (autoCompileThriftEnabled) {
       compileThriftPython.run
-    else {
+    } else {
       log.info("%s: not auto-compiling thrift-python; you may need to run compile-thrift-python manually".format(name))
       None
     }

--- a/src/main/scala/com/twitter/sbt/CompileThriftPython.scala
+++ b/src/main/scala/com/twitter/sbt/CompileThriftPython.scala
@@ -4,8 +4,8 @@ import _root_.sbt._
 
 trait CompileThriftPython extends CompileThrift {
   val compileThriftPythonTwistedEnabled = false
-  val thriftSpec = if (compileThriftPythonTwistedEnabled) "py:new_style,twisted" else "py:new_style"
-  lazy val compileThriftPython = compileThriftAction(thriftSpec)
+  val pythonThriftSpec = if (compileThriftPythonTwistedEnabled) "py:new_style,twisted" else "py:new_style"
+  lazy val compileThriftPython = compileThriftAction(pythonThriftSpec)
 
   lazy val autoCompileThriftPython = task {
     if (autoCompileThriftEnabled)

--- a/src/main/scala/com/twitter/sbt/CompileThriftPython.scala
+++ b/src/main/scala/com/twitter/sbt/CompileThriftPython.scala
@@ -2,16 +2,14 @@ package com.twitter.sbt
 
 import _root_.sbt._
 
-
 trait CompileThriftPython extends CompileThrift {
-  lazy val compileThriftPython =
-    compileThriftAction("py:new_style") describedAs("Compile thrift into python")
+  lazy val compileThriftPython = compileThriftAction("py:new_style")
 
   lazy val autoCompileThriftPython = task {
     if (autoCompileThriftEnabled)
       compileThriftPython.run
     else {
-      log.info(name+": not auto-compiling thrift-python; you may need to run compile-thrift-python manually")
+      log.info("%s: not auto-compiling thrift-python; you may need to run compile-thrift-python manually".format(name))
       None
     }
   }
@@ -19,7 +17,18 @@ trait CompileThriftPython extends CompileThrift {
   override def compileAction = super.compileAction dependsOn(autoCompileThriftPython)
 }
 
-trait CompileThriftPythonTwisted extends CompileThriftPython {
-  override lazy val compileThriftPython =
-    compileThriftAction("py:new_style,twisted") describedAs("Compile thrift into twisted python")
+trait CompileThriftPythonTwisted extends CompileThrift {
+  override lazy val compileThriftPythonTwisted = compileThriftAction("py:new_style,twisted")
+
+  lazy val autoCompileThriftPythonTwisted = task {
+    if (autoCompileThriftEnabled)
+      compileThriftPythonTwisted.run
+    else {
+      log.info("%s: not auto-compiling thrift-python-twisted; you may need to run compile-thrift-python-twisted manually".format(name))
+      None
+    }
+  }
+
+  override def compileAction = super.compileAction dependsOn(autoCompileThriftPythonTwisted)
+
 }

--- a/src/main/scala/com/twitter/sbt/CompileThriftPython.scala
+++ b/src/main/scala/com/twitter/sbt/CompileThriftPython.scala
@@ -3,7 +3,7 @@ package com.twitter.sbt
 import _root_.sbt._
 
 
-trait CompileThriftRuby extends CompileThrift {
+trait CompileThriftPython extends CompileThrift {
   lazy val compileThriftPython =
     compileThriftAction("py:new_style") describedAs("Compile thrift into python")
 
@@ -20,6 +20,6 @@ trait CompileThriftRuby extends CompileThrift {
 }
 
 trait CompileThriftPythonTwisted extends CompileThriftPython {
-  lazy val compileThriftPython =
+  override lazy val compileThriftPython =
     compileThriftAction("py:new_style,twisted") describedAs("Compile thrift into twisted python")
 }

--- a/src/main/scala/com/twitter/sbt/CompileThriftPython.scala
+++ b/src/main/scala/com/twitter/sbt/CompileThriftPython.scala
@@ -1,0 +1,25 @@
+package com.twitter.sbt
+
+import _root_.sbt._
+
+
+trait CompileThriftRuby extends CompileThrift {
+  lazy val compileThriftPython =
+    compileThriftAction("py:new_style") describedAs("Compile thrift into python")
+
+  lazy val autoCompileThriftPython = task {
+    if (autoCompileThriftEnabled)
+      compileThriftPython.run
+    else {
+      log.info(name+": not auto-compiling thrift-python; you may need to run compile-thrift-python manually")
+      None
+    }
+  }
+
+  override def compileAction = super.compileAction dependsOn(autoCompileThriftPython)
+}
+
+trait CompileThriftPythonTwisted extends CompileThriftPython {
+  lazy val compileThriftPython =
+    compileThriftAction("py:new_style,twisted") describedAs("Compile thrift into twisted python")
+}

--- a/src/main/scala/com/twitter/sbt/CompileThriftPython.scala
+++ b/src/main/scala/com/twitter/sbt/CompileThriftPython.scala
@@ -3,7 +3,9 @@ package com.twitter.sbt
 import _root_.sbt._
 
 trait CompileThriftPython extends CompileThrift {
-  lazy val compileThriftPython = compileThriftAction("py:new_style")
+  val compileThriftPythonTwistedEnabled = false
+  val thriftSpec = if (compileThriftPythonTwistedEnabled) "py:new_style,twisted" else "py:new_style"
+  lazy val compileThriftPython = compileThriftAction(thriftSpec)
 
   lazy val autoCompileThriftPython = task {
     if (autoCompileThriftEnabled)
@@ -15,20 +17,4 @@ trait CompileThriftPython extends CompileThrift {
   }
 
   override def compileAction = super.compileAction dependsOn(autoCompileThriftPython)
-}
-
-trait CompileThriftPythonTwisted extends CompileThrift {
-  override lazy val compileThriftPythonTwisted = compileThriftAction("py:new_style,twisted")
-
-  lazy val autoCompileThriftPythonTwisted = task {
-    if (autoCompileThriftEnabled)
-      compileThriftPythonTwisted.run
-    else {
-      log.info("%s: not auto-compiling thrift-python-twisted; you may need to run compile-thrift-python-twisted manually".format(name))
-      None
-    }
-  }
-
-  override def compileAction = super.compileAction dependsOn(autoCompileThriftPythonTwisted)
-
 }

--- a/src/main/scala/com/twitter/sbt/CompileThriftRuby.scala
+++ b/src/main/scala/com/twitter/sbt/CompileThriftRuby.scala
@@ -1,0 +1,18 @@
+package com.twitter.sbt
+
+import _root_.sbt._
+
+
+trait CompileThriftRuby extends CompileThrift {
+  lazy val compileThriftRuby = compileThriftAction("rb") describedAs("Compile thrift into ruby")
+
+  lazy val autoCompileThriftRuby = task {
+    if (autoCompileThriftEnabled) compileThriftRuby.run
+    else {
+      log.info(name+": not auto-compiling thrift-ruby; you may need to run compile-thrift-ruby manually")
+      None
+    }
+  }
+
+  override def compileAction = super.compileAction dependsOn(autoCompileThriftRuby)
+}

--- a/src/main/scala/com/twitter/sbt/CompileThriftRuby.scala
+++ b/src/main/scala/com/twitter/sbt/CompileThriftRuby.scala
@@ -4,12 +4,13 @@ import _root_.sbt._
 
 
 trait CompileThriftRuby extends CompileThrift {
-  lazy val compileThriftRuby = compileThriftAction("rb") describedAs("Compile thrift into ruby")
+  lazy val compileThriftRuby = compileThriftAction("rb")
 
   lazy val autoCompileThriftRuby = task {
-    if (autoCompileThriftEnabled) compileThriftRuby.run
+    if (autoCompileThriftEnabled)
+      compileThriftRuby.run
     else {
-      log.info(name+": not auto-compiling thrift-ruby; you may need to run compile-thrift-ruby manually")
+      log.info("%s: not auto-compiling thrift-ruby; you may need to run compile-thrift-java manually".format(name))
       None
     }
   }

--- a/src/main/scala/com/twitter/sbt/CompileThriftRuby.scala
+++ b/src/main/scala/com/twitter/sbt/CompileThriftRuby.scala
@@ -7,9 +7,9 @@ trait CompileThriftRuby extends CompileThrift {
   lazy val compileThriftRuby = compileThriftAction("rb")
 
   lazy val autoCompileThriftRuby = task {
-    if (autoCompileThriftEnabled)
+    if (autoCompileThriftEnabled) {
       compileThriftRuby.run
-    else {
+    } else {
       log.info("%s: not auto-compiling thrift-ruby; you may need to run compile-thrift-java manually".format(name))
       None
     }

--- a/src/main/scala/com/twitter/sbt/CompileThriftScala.scala
+++ b/src/main/scala/com/twitter/sbt/CompileThriftScala.scala
@@ -29,7 +29,10 @@ trait CompileThriftScala extends DefaultProject with CompileThriftRuby with Comp
     container.runScriptlet(reader, "__TMP__")
     val module = container.runScriptlet("Codegen")
     for ((_rubyThriftNamespace, _javaThriftNamespace) <- originalThriftNamespaces) {
-      container.callMethod(module, "run", (outputPath / generatedRubyDirectoryName ##).toString, (outputPath / generatedScalaDirectoryName ##).toString, _javaThriftNamespace, _rubyThriftNamespace, scalaThriftTargetNamespace)
+      container.callMethod(module, "run",
+        (outputPath / generatedRubyDirectoryName ##).toString,
+        (outputPath / generatedScalaDirectoryName ##).toString,
+        _javaThriftNamespace, _rubyThriftNamespace, scalaThriftTargetNamespace)
     }
     None
   }.dependsOn(autoCompileThriftRuby)

--- a/src/main/scala/com/twitter/sbt/CompileThriftScala.scala
+++ b/src/main/scala/com/twitter/sbt/CompileThriftScala.scala
@@ -10,7 +10,7 @@ import org.jruby.embed._
  * called "quack", that has an extremely heinous thrift IDL, which exercises every thrift type
  * (with nesting and structs).  Grab it and compile it, to make sure this still works :).
  */
-trait CompileThriftScala extends DefaultProject with with CompileThriftRuby with CompileThriftFinagle {
+trait CompileThriftScala extends DefaultProject with CompileThriftRuby with CompileThriftFinagle {
   def scalaThriftTargetNamespace: String
 
   @Deprecated

--- a/src/main/scala/com/twitter/sbt/CompileThriftScala.scala
+++ b/src/main/scala/com/twitter/sbt/CompileThriftScala.scala
@@ -10,7 +10,7 @@ import org.jruby.embed._
  * called "quack", that has an extremely heinous thrift IDL, which exercises every thrift type
  * (with nesting and structs).  Grab it and compile it, to make sure this still works :).
  */
-trait CompileThriftScala extends DefaultProject with CompileThriftFinagle {
+trait CompileThriftScala extends DefaultProject with with CompileThriftRuby with CompileThriftFinagle {
   def scalaThriftTargetNamespace: String
 
   @Deprecated

--- a/src/main/scala/com/twitter/sbt/GeneratedSources.scala
+++ b/src/main/scala/com/twitter/sbt/GeneratedSources.scala
@@ -3,16 +3,19 @@ package com.twitter.sbt
 import _root_.sbt._
 
 trait GeneratedSources extends DefaultProject {
-  def generatedJavaDirectoryName = "gen-java"
-  def generatedRubyDirectoryName = "gen-rb"
+  def generatedJavaDirectoryName   = "gen-java"
+  def generatedRubyDirectoryName   = "gen-rb"
+  def generatedPythonDirectoryName = "gen-py"
 
-  def generatedJavaPath = outputPath / generatedJavaDirectoryName
-  def generatedRubyPath = outputPath / generatedRubyDirectoryName
+  def generatedJavaPath   = outputPath / generatedJavaDirectoryName
+  def generatedRubyPath   = outputPath / generatedRubyDirectoryName
+  def generatedPythonPath = outputPath / generatedPythonDirectoryName
 
   override def mainSourceRoots = super.mainSourceRoots +++ (outputPath / generatedJavaDirectoryName ##)
 
-  lazy val cleanGenerated = (cleanTask(generatedJavaPath) && cleanTask(generatedRubyPath)) describedAs
-    "Clean generated source folders"
+  lazy val cleanGenerated = (
+      cleanTask(generatedJavaPath) && cleanTask(generatedRubyPath) && cleanTask(generatedPythonPath)
+    ) describedAs "Clean generated source folders"
 
   override def cleanAction = super.cleanAction dependsOn(cleanGenerated)
 }


### PR DESCRIPTION
This change refactors CompileThriftRuby out of CompileThriftJava, and also introduces CompileThriftPython and CompileThriftPythonTwisted (all of which extend the common base CompileThrift).
